### PR TITLE
docs: include CONTRIBUTING.md to the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## CONTRIBUTING
+
+This repository is maintained by the Terraform Baseline team.
+
+### Steps
+
+1. Create a new branch.
+1. Commit your changes.
+1. Create a pull request.
+1. Request a review.
+1. Once approved, merge to branch `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,3 @@
-## CONTRIBUTING
+# Contributing guidelines
 
-This repository is maintained by the Terraform Baseline team.
-
-### Steps
-
-1. Create a new branch.
-1. Commit your changes.
-1. Create a pull request.
-1. Request a review.
-1. Once approved, merge to branch `main`.
+This project has adopted the [Equinor Terraform Baseline contributing guidelines](https://github.com/equinor/terraform-baseline/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Include CONTRIBUTING.md to the Repository to keep up with the current policies for source code management (SCM) system usage in Equinor.