### PR TITLE
feat: update SKU validation to include developer and premium options

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -34,8 +34,8 @@ variable "sku" {
   nullable    = false
 
   validation {
-    condition     = contains(["free", "standard"], var.sku)
-    error_message = "Sku must be \"free\" or \"standard\"."
+    condition     = contains(["free", "developer", "standard", "premium"], var.sku)
+    error_message = "Sku must be \"free\", \"developer\", \"standard\", or \"premium\"."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "log_analytics_workspace_id" {
 }
 
 variable "sku" {
-  description = "The SKU of this App Configuration store. Value must be \"free\" or \"standard\"."
+  description = "The SKU of this App Configuration store. Value must be \"free\", \"developer\", \"standard\", or \"premium\"."
   type        = string
   default     = "standard"
   nullable    = false

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      version = ">= 4.29.0"
     }
   }
 }


### PR DESCRIPTION
There are more SKU's available for appconfig than what is currently supported by this module.

Personally I need "developer" sku,  as they are a lot cheaper.

<img width="841" height="91" alt="image" src="https://github.com/user-attachments/assets/c177f630-6245-4457-8157-d38b02bf1735" />
