### PR TITLE
feat: add prevent_destroy variable to allow overwrite control lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_app_configuration" "this" {
 
   lifecycle {
     # Prevent accidental destroy of App Configuration store.
-    prevent_destroy = true
+    prevent_destroy = var.prevent_destroy
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,10 @@ variable "tags" {
   default     = {}
   nullable    = false
 }
+
+variable "prevent_destroy" {
+  description = "Overwrite the lifecycle prevent_destroy option for the App Configuration store resource."
+  type        = bool
+  default     = true
+  nullable    = false
+}


### PR DESCRIPTION
This will create an option to disable destroy prevention. 
My usecase is that I want to downgrade sku from default to developer, which I'm currently unable to do.

<img width="820" height="330" alt="image" src="https://github.com/user-attachments/assets/42d02a18-c7cb-4b03-a993-beb943afa657" />
